### PR TITLE
feat(07): add third solution to exercise 07 using 'or' function

### DIFF
--- a/src/07-union.solution.3.ts
+++ b/src/07-union.solution.3.ts
@@ -1,0 +1,42 @@
+// CODE
+
+import { expect, it } from "vitest";
+import { z } from "zod";
+
+const Form = z.object({
+  repoName: z.string(),
+  privacyLevel: z.literal("private").or(z.literal("public")),
+});
+
+export const validateFormInput = (values: unknown) => {
+  const parsedData = Form.parse(values);
+
+  return parsedData;
+};
+
+// TESTS
+
+it("Should fail if an invalid privacyLevel passed", async () => {
+  expect(() =>
+    validateFormInput({
+      repoName: "mattpocock",
+      privacyLevel: "something-not-allowed",
+    }),
+  ).toThrowError();
+});
+
+it("Should permit valid privacy levels", async () => {
+  expect(
+    validateFormInput({
+      repoName: "mattpocock",
+      privacyLevel: "private",
+    }).privacyLevel,
+  ).toEqual("private");
+
+  expect(
+    validateFormInput({
+      repoName: "mattpocock",
+      privacyLevel: "public",
+    }).privacyLevel,
+  ).toEqual("public");
+});


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Exercise 07  solutions don't contain the "or" usage alternative

Fixes: #4 

## What is the new behavior?

Exercise 07 has a third solution using the "or" function from Zod
