### PR TITLE
Ex 14 possible solution

### DIFF
--- a/src/14-generics.solution.2.ts
+++ b/src/14-generics.solution.2.ts
@@ -1,0 +1,30 @@
+// CODE
+
+import { it } from "vitest";
+import { z } from "zod";
+import { Equal, Expect } from "./helpers/type-utils";
+
+const genericFetch = <ZSchema>(
+  url: string,
+  schema: z.ZodSchema<ZSchema>,
+) => {
+  return fetch(url)
+    .then((res) => res.json())
+    .then((result) => schema.parse(result));
+};
+
+// TESTS
+
+it("Should fetch from the Star Wars API", async () => {
+  const result = await genericFetch(
+    "https://swapi.dev/api/people/1",
+    z.object({
+      name: z.string(),
+    }),
+  );
+
+  type cases = [
+    // Result should equal { name: string }, not any
+    Expect<Equal<typeof result, { name: string }>>,
+  ];
+});


### PR DESCRIPTION
By passing our generic into the first generic slot on `z.ZodSchema`, the return type is inferred for free 😄 