### PR TITLE
Remove reference to video in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This tutorial encourages **active, exploratory learning**. In the video, I'll ex
 
 You'll know if you've succeeded because the tests will pass.
 
-**If you succeed**, or **if you get stuck**, unpause the video and check out the `*.solution.ts`. You can see if your solution is better or worse than mine!
+**If you succeed**, or **if you get stuck**, check out the `*.solution.ts`. You can see if your solution is better or worse than mine!
 
 You can run `yarn solution 01` to run the tests and typechecking on the solution.
 


### PR DESCRIPTION
The previous PR removed the mention of the YouTube video (which was included as a TODO previously). This further cleans up the README by removing the other reference to using a video.

I'm not sure whether the video is still planned to be included, but until it is it might be best to avoid confusion!